### PR TITLE
Last commit didn't include isLoggedIn in client

### DIFF
--- a/src/org/rev317/min/accessors/Client.java
+++ b/src/org/rev317/min/accessors/Client.java
@@ -50,4 +50,6 @@ public interface Client {
     public int[] getCurrentStats();
 
     public int[] getSettings();
+
+    public boolean isLoggedIn();
 }


### PR DESCRIPTION
The last commit attempted to solve the loggedIn issue.
It seems like the abstract method in accessors.Client was missing.
I've added it.