### PR TITLE
Split objects debug up into all & each of the 5 types

### DIFF
--- a/src/main/java/org/rev317/min/debug/DSceneObjectsGroundDec.java
+++ b/src/main/java/org/rev317/min/debug/DSceneObjectsGroundDec.java
@@ -4,28 +4,22 @@ import org.parabot.core.Context;
 import org.parabot.core.paint.AbstractDebugger;
 import org.parabot.core.paint.PaintDebugger;
 import org.parabot.core.ui.Logger;
-import org.rev317.min.api.methods.GroundItems;
+import org.parabot.environment.api.utils.Filter;
 import org.rev317.min.api.methods.SceneObjects;
 import org.rev317.min.api.wrappers.SceneObject;
 
 import java.awt.*;
-import java.util.Comparator;
+import java.util.Arrays;
+import java.util.Collections;
 
-public class DSceneObjects extends AbstractDebugger {
+public class DSceneObjectsGroundDec extends AbstractDebugger {
 
     private boolean enabled;
-
-    public static final Comparator<SceneObject> SCENE_OBJECT_COMPARATOR_DISTANCE = new Comparator<SceneObject>() {
-        @Override
-        public int compare(SceneObject o1, SceneObject o2) {
-            return o1.distanceTo() > o2.distanceTo() ? 1 : o1.distanceTo() == o2.distanceTo() ? 0 : -1;
-        }
-    };
 
     @Override
     public void paint(Graphics g) {
         PaintDebugger p = Context.getInstance().getPaintDebugger();
-        p.addLine("Close SceneObjects: " + SceneObjects.getNearest().length);
+        p.addLine("Ground decorations: " + getGroundDecorations().length);
     }
 
     @Override
@@ -38,11 +32,14 @@ public class DSceneObjects extends AbstractDebugger {
         enabled = !enabled;
 
         if (enabled) {
-            SceneObject[] objects = SceneObjects.getNearest();
+            SceneObject[] objects = getGroundDecorations();
             if (objects == null || objects.length == 0) {
                 Logger.addMessage("There are no GameObjects around you.");
                 return;
             }
+            java.util.List<SceneObject> objs = Arrays.asList(objects);
+            Collections.sort(objs, DSceneObjects.SCENE_OBJECT_COMPARATOR_DISTANCE);
+            objects = objs.toArray(new SceneObject[0]);
 
             for (int i = objects.length - 1; i >= 0; i--) {
                 System.out.println(
@@ -52,5 +49,14 @@ public class DSceneObjects extends AbstractDebugger {
                                 " Distance: " + objects[i].distanceTo());
             }
         }
+    }
+
+    private SceneObject[] getGroundDecorations() {
+        return SceneObjects.getNearest(new Filter<SceneObject>() {
+            @Override
+            public boolean accept(SceneObject sceneObject) {
+                return sceneObject.getType() == SceneObject.TYPE_GROUNDDECORATION;
+            }
+        });
     }
 }

--- a/src/main/java/org/rev317/min/debug/DSceneObjectsGroundItems.java
+++ b/src/main/java/org/rev317/min/debug/DSceneObjectsGroundItems.java
@@ -4,28 +4,22 @@ import org.parabot.core.Context;
 import org.parabot.core.paint.AbstractDebugger;
 import org.parabot.core.paint.PaintDebugger;
 import org.parabot.core.ui.Logger;
-import org.rev317.min.api.methods.GroundItems;
+import org.parabot.environment.api.utils.Filter;
 import org.rev317.min.api.methods.SceneObjects;
 import org.rev317.min.api.wrappers.SceneObject;
 
 import java.awt.*;
-import java.util.Comparator;
+import java.util.Arrays;
+import java.util.Collections;
 
-public class DSceneObjects extends AbstractDebugger {
+public class DSceneObjectsGroundItems extends AbstractDebugger {
 
     private boolean enabled;
-
-    public static final Comparator<SceneObject> SCENE_OBJECT_COMPARATOR_DISTANCE = new Comparator<SceneObject>() {
-        @Override
-        public int compare(SceneObject o1, SceneObject o2) {
-            return o1.distanceTo() > o2.distanceTo() ? 1 : o1.distanceTo() == o2.distanceTo() ? 0 : -1;
-        }
-    };
 
     @Override
     public void paint(Graphics g) {
         PaintDebugger p = Context.getInstance().getPaintDebugger();
-        p.addLine("Close SceneObjects: " + SceneObjects.getNearest().length);
+        p.addLine("Ground Items: " + getGroundItems().length);
     }
 
     @Override
@@ -38,11 +32,14 @@ public class DSceneObjects extends AbstractDebugger {
         enabled = !enabled;
 
         if (enabled) {
-            SceneObject[] objects = SceneObjects.getNearest();
+            SceneObject[] objects = getGroundItems();
             if (objects == null || objects.length == 0) {
                 Logger.addMessage("There are no GameObjects around you.");
                 return;
             }
+            java.util.List<SceneObject> objs = Arrays.asList(objects);
+            Collections.sort(objs, DSceneObjects.SCENE_OBJECT_COMPARATOR_DISTANCE);
+            objects = objs.toArray(new SceneObject[0]);
 
             for (int i = objects.length - 1; i >= 0; i--) {
                 System.out.println(
@@ -52,5 +49,14 @@ public class DSceneObjects extends AbstractDebugger {
                                 " Distance: " + objects[i].distanceTo());
             }
         }
+    }
+
+    private SceneObject[] getGroundItems() {
+        return SceneObjects.getSceneObjects(new Filter<SceneObject>() {
+            @Override
+            public boolean accept(SceneObject sceneObject) {
+                return sceneObject.getType() == SceneObject.TYPE_GROUNDITEM;
+            }
+        });
     }
 }

--- a/src/main/java/org/rev317/min/debug/DSceneObjectsInteractiveObj.java
+++ b/src/main/java/org/rev317/min/debug/DSceneObjectsInteractiveObj.java
@@ -4,28 +4,23 @@ import org.parabot.core.Context;
 import org.parabot.core.paint.AbstractDebugger;
 import org.parabot.core.paint.PaintDebugger;
 import org.parabot.core.ui.Logger;
-import org.rev317.min.api.methods.GroundItems;
+import org.parabot.environment.api.utils.Filter;
 import org.rev317.min.api.methods.SceneObjects;
 import org.rev317.min.api.wrappers.SceneObject;
 
 import java.awt.*;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 
-public class DSceneObjects extends AbstractDebugger {
+public class DSceneObjectsInteractiveObj extends AbstractDebugger {
 
     private boolean enabled;
-
-    public static final Comparator<SceneObject> SCENE_OBJECT_COMPARATOR_DISTANCE = new Comparator<SceneObject>() {
-        @Override
-        public int compare(SceneObject o1, SceneObject o2) {
-            return o1.distanceTo() > o2.distanceTo() ? 1 : o1.distanceTo() == o2.distanceTo() ? 0 : -1;
-        }
-    };
 
     @Override
     public void paint(Graphics g) {
         PaintDebugger p = Context.getInstance().getPaintDebugger();
-        p.addLine("Close SceneObjects: " + SceneObjects.getNearest().length);
+        p.addLine("Interactive Objects: " + getInteractiveObjects().length);
     }
 
     @Override
@@ -38,11 +33,14 @@ public class DSceneObjects extends AbstractDebugger {
         enabled = !enabled;
 
         if (enabled) {
-            SceneObject[] objects = SceneObjects.getNearest();
+            SceneObject[] objects = getInteractiveObjects();
             if (objects == null || objects.length == 0) {
                 Logger.addMessage("There are no GameObjects around you.");
                 return;
             }
+            java.util.List<SceneObject> objs = Arrays.asList(objects);
+            Collections.sort(objs, DSceneObjects.SCENE_OBJECT_COMPARATOR_DISTANCE);
+            objects = objs.toArray(new SceneObject[0]);
 
             for (int i = objects.length - 1; i >= 0; i--) {
                 System.out.println(
@@ -52,5 +50,14 @@ public class DSceneObjects extends AbstractDebugger {
                                 " Distance: " + objects[i].distanceTo());
             }
         }
+    }
+
+    private SceneObject[] getInteractiveObjects() {
+        return SceneObjects.getSceneObjects(new Filter<SceneObject>() {
+            @Override
+            public boolean accept(SceneObject sceneObject) {
+                return sceneObject.getType() == SceneObject.TYPE_INTERACTIVE;
+            }
+        });
     }
 }

--- a/src/main/java/org/rev317/min/debug/DSceneObjectsWallDec.java
+++ b/src/main/java/org/rev317/min/debug/DSceneObjectsWallDec.java
@@ -4,28 +4,22 @@ import org.parabot.core.Context;
 import org.parabot.core.paint.AbstractDebugger;
 import org.parabot.core.paint.PaintDebugger;
 import org.parabot.core.ui.Logger;
-import org.rev317.min.api.methods.GroundItems;
+import org.parabot.environment.api.utils.Filter;
 import org.rev317.min.api.methods.SceneObjects;
 import org.rev317.min.api.wrappers.SceneObject;
 
 import java.awt.*;
-import java.util.Comparator;
+import java.util.Arrays;
+import java.util.Collections;
 
-public class DSceneObjects extends AbstractDebugger {
+public class DSceneObjectsWallDec extends AbstractDebugger {
 
     private boolean enabled;
-
-    public static final Comparator<SceneObject> SCENE_OBJECT_COMPARATOR_DISTANCE = new Comparator<SceneObject>() {
-        @Override
-        public int compare(SceneObject o1, SceneObject o2) {
-            return o1.distanceTo() > o2.distanceTo() ? 1 : o1.distanceTo() == o2.distanceTo() ? 0 : -1;
-        }
-    };
 
     @Override
     public void paint(Graphics g) {
         PaintDebugger p = Context.getInstance().getPaintDebugger();
-        p.addLine("Close SceneObjects: " + SceneObjects.getNearest().length);
+        p.addLine("Wall decorations: " + getWallDecorations().length);
     }
 
     @Override
@@ -38,11 +32,14 @@ public class DSceneObjects extends AbstractDebugger {
         enabled = !enabled;
 
         if (enabled) {
-            SceneObject[] objects = SceneObjects.getNearest();
+            SceneObject[] objects = getWallDecorations();
             if (objects == null || objects.length == 0) {
                 Logger.addMessage("There are no GameObjects around you.");
                 return;
             }
+            java.util.List<SceneObject> objs = Arrays.asList(objects);
+            Collections.sort(objs, DSceneObjects.SCENE_OBJECT_COMPARATOR_DISTANCE);
+            objects = objs.toArray(new SceneObject[0]);
 
             for (int i = objects.length - 1; i >= 0; i--) {
                 System.out.println(
@@ -52,5 +49,14 @@ public class DSceneObjects extends AbstractDebugger {
                                 " Distance: " + objects[i].distanceTo());
             }
         }
+    }
+
+    private SceneObject[] getWallDecorations() {
+        return SceneObjects.getNearest(new Filter<SceneObject>() {
+            @Override
+            public boolean accept(SceneObject sceneObject) {
+                return sceneObject.getType() == SceneObject.TYPE_WALLDECORATION;
+            }
+        });
     }
 }

--- a/src/main/java/org/rev317/min/debug/DSceneObjectsWallObj.java
+++ b/src/main/java/org/rev317/min/debug/DSceneObjectsWallObj.java
@@ -4,28 +4,22 @@ import org.parabot.core.Context;
 import org.parabot.core.paint.AbstractDebugger;
 import org.parabot.core.paint.PaintDebugger;
 import org.parabot.core.ui.Logger;
-import org.rev317.min.api.methods.GroundItems;
+import org.parabot.environment.api.utils.Filter;
 import org.rev317.min.api.methods.SceneObjects;
 import org.rev317.min.api.wrappers.SceneObject;
 
 import java.awt.*;
-import java.util.Comparator;
+import java.util.Arrays;
+import java.util.Collections;
 
-public class DSceneObjects extends AbstractDebugger {
+public class DSceneObjectsWallObj extends AbstractDebugger {
 
     private boolean enabled;
-
-    public static final Comparator<SceneObject> SCENE_OBJECT_COMPARATOR_DISTANCE = new Comparator<SceneObject>() {
-        @Override
-        public int compare(SceneObject o1, SceneObject o2) {
-            return o1.distanceTo() > o2.distanceTo() ? 1 : o1.distanceTo() == o2.distanceTo() ? 0 : -1;
-        }
-    };
 
     @Override
     public void paint(Graphics g) {
         PaintDebugger p = Context.getInstance().getPaintDebugger();
-        p.addLine("Close SceneObjects: " + SceneObjects.getNearest().length);
+        p.addLine("Wall objects: " + getWallObjects().length);
     }
 
     @Override
@@ -38,11 +32,14 @@ public class DSceneObjects extends AbstractDebugger {
         enabled = !enabled;
 
         if (enabled) {
-            SceneObject[] objects = SceneObjects.getNearest();
+            SceneObject[] objects = getWallObjects();
             if (objects == null || objects.length == 0) {
                 Logger.addMessage("There are no GameObjects around you.");
                 return;
             }
+            java.util.List<SceneObject> objs = Arrays.asList(objects);
+            Collections.sort(objs, DSceneObjects.SCENE_OBJECT_COMPARATOR_DISTANCE);
+            objects = objs.toArray(new SceneObject[0]);
 
             for (int i = objects.length - 1; i >= 0; i--) {
                 System.out.println(
@@ -52,5 +49,14 @@ public class DSceneObjects extends AbstractDebugger {
                                 " Distance: " + objects[i].distanceTo());
             }
         }
+    }
+
+    private SceneObject[] getWallObjects() {
+        return SceneObjects.getNearest(new Filter<SceneObject>() {
+            @Override
+            public boolean accept(SceneObject sceneObject) {
+                return sceneObject.getType() == SceneObject.TYPE_WALL;
+            }
+        });
     }
 }

--- a/src/main/java/org/rev317/min/ui/BotMenu.java
+++ b/src/main/java/org/rev317/min/ui/BotMenu.java
@@ -32,7 +32,13 @@ public class BotMenu implements ActionListener {
         JMenuItem messages   = newItem("Messages");
         JMenuItem mouse      = newItem("Mouse");
         JMenuItem npcs       = newItem("Npcs");
-        JMenuItem objects    = newItem("Objects");
+        JMenu objects    = new JMenu("Objects");
+        JMenuItem enableAllObject = newItem("Enable All Objects");
+        JMenuItem groundDecorations = newItem("Ground Decorations");
+        JMenuItem interactiveObjects = newItem("Interactive Objects");
+        JMenuItem wallObjects = newItem("Wall Objects");
+        JMenuItem wallDecorations = newItem("Wall Decorations");
+        JMenuItem groundItems = newItem("Ground Items");
         JMenuItem players    = newItem("Players");
         JMenuItem skills    = newItem("Skills");
 
@@ -47,7 +53,12 @@ public class BotMenu implements ActionListener {
         debugger.addDebugger("Messages", new DMessages());
         debugger.addDebugger("Mouse", new DMouse());
         debugger.addDebugger("Npcs", new DNpcs());
-        debugger.addDebugger("Objects", new DSceneObjects());
+        debugger.addDebugger("Enable All Objects", new DSceneObjects());
+        debugger.addDebugger("Ground Decorations", new DSceneObjectsGroundDec());
+        debugger.addDebugger("Interactive Objects", new DSceneObjectsInteractiveObj());
+        debugger.addDebugger("Wall Objects", new DSceneObjectsWallObj());
+        debugger.addDebugger("Wall Decorations", new DSceneObjectsWallDec());
+        debugger.addDebugger("Ground Items", new DSceneObjectsGroundItems());
         debugger.addDebugger("Players", new DPlayers());
         debugger.addDebugger("Skills", new DSkills());
 
@@ -64,6 +75,13 @@ public class BotMenu implements ActionListener {
         debug.add(mouse);
         debug.add(npcs);
         debug.add(objects);
+        objects.add(enableAllObject);
+        objects.addSeparator();
+        objects.add(groundDecorations);
+        objects.add(groundItems);
+        objects.add(wallDecorations);
+        objects.add(wallObjects);
+        objects.add(interactiveObjects);
         debug.add(players);
         debug.add(skills);
 


### PR DESCRIPTION
Useful for printing type-specific SceneObjects to the Console when debug is turned on. 'All' is still the all-in-one DSceneObjects of all types, and does not turn on the 5 individual ones.

![alt](https://i.imgur.com/4Qce7Do.jpg)