### PR TITLE
[BUGFIX] Select debug 0 as default output

### DIFF
--- a/src/main/java/org/rev317/min/ui/BotMenu.java
+++ b/src/main/java/org/rev317/min/ui/BotMenu.java
@@ -99,6 +99,11 @@ public class BotMenu implements ActionListener {
                 }
             });
             group.add(debugOutput);
+
+            if (index == 0) {
+                group.setSelected(debugOutput.getModel(), true);
+            }
+
             actions.add(debugOutput);
         }
 


### PR DESCRIPTION
Checks the debug 0 button at initialization. Underlying it already defaults to 0 so only a UI change was needed.

Fixes issue https://github.com/Parabot/Parabot/issues/217
