### PR TITLE
Pb lord mapfix

### DIFF
--- a/src/main/java/org/rev317/min/debug/DMap.java
+++ b/src/main/java/org/rev317/min/debug/DMap.java
@@ -26,5 +26,7 @@ public class DMap extends AbstractDebugger {
     @Override
     public void toggle() {
         enabled = !enabled;
+        System.out.println("Players location: " + Players.getMyPlayer().getLocation());
+
     }
 }

--- a/src/main/java/org/rev317/min/debug/DMap.java
+++ b/src/main/java/org/rev317/min/debug/DMap.java
@@ -26,7 +26,7 @@ public class DMap extends AbstractDebugger {
     @Override
     public void toggle() {
         enabled = !enabled;
-        System.out.println("Players location: " + Players.getMyPlayer().getLocation());
-
+        System.out.println("Location: " + Players.getMyPlayer().getLocation());
+        System.out.println("Plane: " + Game.getPlane());
     }
 }


### PR DESCRIPTION
Prints players location map coords so mac devs don't have to enable and disable "Disable Dialog" to see map coords